### PR TITLE
Send error_log to `stderr` instead of `/dev/stderr`.

### DIFF
--- a/resty
+++ b/resty
@@ -153,8 +153,8 @@ pid logs/nginx.pid;
 
 $env_list
 
-error_log /dev/stderr warn;
-#error_log /dev/stderr debug;
+error_log stderr warn;
+#error_log stderr debug;
 
 events {
     worker_connections $conns;


### PR DESCRIPTION
The use of `error_log /dev/stderr` prevents usage in cron, at least on Ubuntu 14.04.  It gets the following error:
```
nginx: [emerg] open() "/dev/stderr" failed (13: Permission denied)
```

I tried to understand it fully, but I believe it has something to do with the chain of symlinks and their ownership during the cron -> command invocation process.   Unless there is some specific reason to use /dev/stderr, why not use nginx's built-in  `stderr` directive, which is perhaps fd-based rather than a filesystem path?
