### PR TITLE
Add support for including additional nginx configuration

### DIFF
--- a/resty
+++ b/resty
@@ -19,16 +19,18 @@ use File::Temp qw( tempdir );
 use POSIX qw( WNOHANG );
 
 my @all_args = @ARGV;
-GetOptions("c=i",           \(my $conns_num),
-           "e=s",           \(my $src),
-           "h|help",        \(my $help),
-           "I=s@",          \(my $Inc),
-           "nginx=s",       \(my $nginx_path),
-           "valgrind",      \(my $use_valgrind),
+GetOptions("c=i",             \(my $conns_num),
+           "e=s",             \(my $src),
+           "h|help",          \(my $help),
+           "http-include=s",  \(my $http_include),
+           "I=s@",            \(my $Inc),
+           "main-include=s",  \(my $main_include),
+           "nginx=s",         \(my $nginx_path),
+           "valgrind",        \(my $use_valgrind),
 
            "valgrind-opts=s", \(my $valgrind_opts),
 
-           "V",             \(my $version))
+           "V",               \(my $version))
    or die usage(1);
 
 if ($help) {
@@ -168,6 +170,17 @@ for my $var (sort keys %ENV) {
     $env_list .= "env $var;\n";
 }
 
+my $main_include_directive = '';
+my $http_include_directive = '';
+
+if ($main_include) {
+  $main_include_directive = "include $main_include;"
+}
+
+if ($http_include) {
+  $http_include_directive = "include $http_include;"
+}
+
 my $conf_file = File::Spec->catfile($conf_dir, "nginx.conf");
 open my $out, ">$conf_file"
     or die "Cannot open $conf_file for writing: $!\n";
@@ -187,11 +200,14 @@ events {
     worker_connections $conns;
 }
 
+$main_include_directive
+
 http {
     access_log off;
     lua_socket_log_errors off;
     resolver @nameservers;
 $lua_package_path_config
+    $http_include_directive
     init_by_lua '
         local stdout = io.stdout
         local ngx_null = ngx.null
@@ -350,15 +366,16 @@ sub usage {
 resty [options] [lua-file [args]]
 
 Options:
-    -c num      set maximal connection count (default: 64).
-    -e prog     run the inlined Lua code in "prog".
-    --help      print this help.
-    -I dir      Add dir to the search paths for Lua libraries.
-    --nginx     specify the nginx path (this option might be removed in the future).
-    -V          print version numbers and nginx configurations.
-    --valgrind  use valgrind to run the underyling nginx
-
-    --valgrind-opts     pass extra options to valgrind
+    -c num              Set maximal connection count (default: 64).
+    -e prog             Run the inlined Lua code in "prog".
+    --help              Print this help.
+    --http-include path Include the specified file in the nginx http configuration block
+    -I dir              Add dir to the search paths for Lua libraries.
+    --main-include path Include the specified file in the nginx main configuration block
+    --nginx             Specify the nginx path (this option might be removed in the future).
+    -V                  Print version numbers and nginx configurations.
+    --valgrind          Use valgrind to run nginx
+    --valgrind-opts     Pass extra options to valgrind
 
 For bug reporting instructions, please see:
 <http://openresty.org/#Community>

--- a/resty
+++ b/resty
@@ -174,11 +174,11 @@ my $main_include_directive = '';
 my $http_include_directive = '';
 
 if ($main_include) {
-  $main_include_directive = "include $main_include;"
+    $main_include_directive = "include $main_include;"
 }
 
 if ($http_include) {
-  $http_include_directive = "include $http_include;"
+    $http_include_directive = "include $http_include;"
 }
 
 my $conf_file = File::Spec->catfile($conf_dir, "nginx.conf");

--- a/resty
+++ b/resty
@@ -18,13 +18,28 @@ use Getopt::Long qw( GetOptions :config no_ignore_case require_order);
 use File::Temp qw( tempdir );
 use POSIX qw( WNOHANG );
 
+sub resolve_includes {
+    my $type = shift;
+    my @paths = map {
+        my $abs_path = File::Spec->rel2abs($_);
+        unless (-f $abs_path) {
+          die "Could not find $type include '$abs_path'";
+        }
+        "include $abs_path;";
+    } @_;
+    return join("\n", @paths);
+}
+
 my @all_args = @ARGV;
+my @http_includes = ();
+my @main_includes = ();
+
 GetOptions("c=i",             \(my $conns_num),
            "e=s",             \(my $src),
            "h|help",          \(my $help),
-           "http-include=s",  \(my $http_include),
+           "http-include=s",  \@http_includes,
            "I=s@",            \(my $Inc),
-           "main-include=s",  \(my $main_include),
+           "main-include=s",  \@main_includes,
            "nginx=s",         \(my $nginx_path),
            "valgrind",        \(my $use_valgrind),
 
@@ -170,16 +185,8 @@ for my $var (sort keys %ENV) {
     $env_list .= "env $var;\n";
 }
 
-my $main_include_directive = '';
-my $http_include_directive = '';
-
-if ($main_include) {
-    $main_include_directive = "include $main_include;"
-}
-
-if ($http_include) {
-    $http_include_directive = "include $http_include;"
-}
+my $main_include_directives = resolve_includes('main', @main_includes);
+my $http_include_directives = resolve_includes('http', @http_includes);
 
 my $conf_file = File::Spec->catfile($conf_dir, "nginx.conf");
 open my $out, ">$conf_file"
@@ -200,14 +207,14 @@ events {
     worker_connections $conns;
 }
 
-$main_include_directive
+$main_include_directives
 
 http {
     access_log off;
     lua_socket_log_errors off;
     resolver @nameservers;
 $lua_package_path_config
-    $http_include_directive
+    $http_include_directives
     init_by_lua '
         local stdout = io.stdout
         local ngx_null = ngx.null

--- a/t/resty/options.t
+++ b/t/resty/options.t
@@ -40,15 +40,16 @@ nginx version: /s
 resty [options] [lua-file [args]]
 
 Options:
-    -c num      set maximal connection count (default: 64).
-    -e prog     run the inlined Lua code in "prog".
-    --help      print this help.
-    -I dir      Add dir to the search paths for Lua libraries.
-    --nginx     specify the nginx path (this option might be removed in the future).
-    -V          print version numbers and nginx configurations.
-    --valgrind  use valgrind to run the underyling nginx
-
-    --valgrind-opts     pass extra options to valgrind
+    -c num              Set maximal connection count (default: 64).
+    -e prog             Run the inlined Lua code in "prog".
+    --help              Print this help.
+    --http-include path Include the specified file in the nginx http configuration block
+    -I dir              Add dir to the search paths for Lua libraries.
+    --main-include path Include the specified file in the nginx main configuration block
+    --nginx             Specify the nginx path (this option might be removed in the future).
+    -V                  Print version numbers and nginx configurations.
+    --valgrind          Use valgrind to run nginx
+    --valgrind-opts     Pass extra options to valgrind
 
 For bug reporting instructions, please see:
 <http://openresty.org/#Community>

--- a/t/resty/options.t
+++ b/t/resty/options.t
@@ -56,3 +56,22 @@ For bug reporting instructions, please see:
 --- err
 --- ret: 0
 
+
+
+=== TEST 4: bad --http-include value
+--- opts: --http-include=/tmp/no/such/file
+--- src
+--- out
+--- err_like chop
+Could not find http include '/tmp/no/such/file'
+--- ret: 2
+
+
+
+=== TEST 5: bad --main-include value
+--- opts: --main-include=/tmp/no/such/file
+--- src
+--- out
+--- err_like chop
+Could not find main include '/tmp/no/such/file'
+--- ret: 2


### PR DESCRIPTION
From the commit:

This adds two new command line options, --main-include and --http_include, which allows specifying additional configuration to be included via the `include` directive in the main block and http block, respectively. It also re-formats the usage output to reflect the new flags (also aligns the  the output of existing flags).

Background:

The use case we have at work is that we're using the `resty` runner to run our tests, in order to have nginx APIs available. This works well in general, but a problem we encountered is that we couldn't setup a shared dict cache to be used from within the specs, as that requires (AFAIK) a corresponding nginx directive. So to get this working we needed to be able to alter the nginx configuration used by the `resty` command. While one option would be to add a flag for specifying another configuration file to use, the current configuration used by the `resty` command also contains a lot of support code. So this instead adds the ability to specify addition nginx configuration for the main block and/or http block. It might be that there are better ways of achieving what we want of course.

