### PR TITLE
Don't show error in pod2man in Perl 5.20.2-4

### DIFF
--- a/bin/restydoc
+++ b/bin/restydoc
@@ -559,7 +559,7 @@ sub process_module_hit {
 
 sub get_groff_cmd {
     my $cmd = "groff -Kutf8 -Tutf8 -mandoc -Wbreak";
-    if (system("echo '=head1 NAME' | pod2man --errors none| $cmd > /dev/null 2>&1") == 0) {
+    if (system("echo '=head1 NAME' | pod2man --errors none | $cmd > /dev/null 2>&1") == 0) {
         return $cmd;
     }
     return "groff -Tascii -mandoc -Wbreak";

--- a/bin/restydoc
+++ b/bin/restydoc
@@ -559,7 +559,7 @@ sub process_module_hit {
 
 sub get_groff_cmd {
     my $cmd = "groff -Kutf8 -Tutf8 -mandoc -Wbreak";
-    if (system("echo '=head1 NAME' | pod2man | $cmd > /dev/null 2>&1") == 0) {
+    if (system("echo '=head1 NAME' | pod2man --errors none| $cmd > /dev/null 2>&1") == 0) {
         return $cmd;
     }
     return "groff -Tascii -mandoc -Wbreak";


### PR DESCRIPTION
When using Ubuntu Xenial (16.04) with pod2man (Perl 5.20.2-4) a piped usage of pod2man now requires the '-n' flag to not displaying the following error:
```
IO::File=IO(0x12fcd98) around line 1: No name given for document
POD document had syntax errors at /usr/bin/pod2man line 68.
```

This problem was discussed in https://lists.ubuntu.com/archives/ubuntu-sponsors/2015-October/044687.html and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=777405