### PR TITLE
feat: add --lua-directives argument to resty

### DIFF
--- a/bin/resty
+++ b/bin/resty
@@ -32,12 +32,13 @@ sub resolve_includes {
 
 my @all_args = @ARGV;
 
-my (@http_includes, @main_includes, @src_a);
+my (@http_includes, @main_includes, @lua_directives, @src_a);
 
 GetOptions("c=i",             \(my $conns_num),
            "e=s",             \@src_a,
            "h|help",          \(my $help),
            "http-include=s",  \@http_includes,
+           "lua-directive=s", \@lua_directives,
            "I=s@",            \(my $Inc),
            "main-include=s",  \@main_includes,
            "nginx=s",         \(my $nginx_path),
@@ -208,6 +209,7 @@ for my $var (sort keys %ENV) {
 
 my $main_include_directives = resolve_includes('main', @main_includes);
 my $http_include_directives = resolve_includes('http', @http_includes);
+my $lua_directives_list = join("\n    ", @lua_directives);
 
 my $conf_file = File::Spec->catfile($conf_dir, "nginx.conf");
 open my $out, ">$conf_file"
@@ -234,6 +236,7 @@ http {
     access_log off;
     lua_socket_log_errors off;
     resolver @nameservers;
+    $lua_directives_list
 $lua_package_path_config
     $http_include_directives
     init_by_lua '
@@ -406,6 +409,9 @@ Options:
 
     --main-include path Include the specified file in the nginx main configuration block
                         (multiple instances are supported).
+
+    --lua-directives    Include the specified lua-nginx-module directives in the http
+                        configuration block (multiple instances are supported).
 
     --nginx             Specify the nginx path (this option might be removed in the future).
     -V                  Print version numbers and nginx configurations.

--- a/t/resty/options.t
+++ b/t/resty/options.t
@@ -52,6 +52,9 @@ Options:
     --main-include path Include the specified file in the nginx main configuration block
                         (multiple instances are supported).
 
+    --lua-directives    Include the specified lua-nginx-module directives in the http
+                        configuration block (multiple instances are supported).
+
     --nginx             Specify the nginx path (this option might be removed in the future).
     -V                  Print version numbers and nginx configurations.
     --valgrind          Use valgrind to run nginx
@@ -188,7 +191,36 @@ bar: 56
 
 
 
-=== TEST 12: multiple -e options
+=== TEST 12: --lua-directive option
+--- opts: '--lua-directive=lua_shared_dict dogs 12k;'
+--- src
+local dogs = ngx.shared.dogs
+dogs:set("Tom", 32)
+print(dogs:get("Tom"))
+--- out
+32
+--- err
+
+
+
+=== TEST 12: multiple --lua-directive option
+--- opts: '--lua-directive=lua_shared_dict dogs 1m;' '--lua-directive=lua_shared_dict cats 1m;'
+--- src
+local dogs = ngx.shared.dogs
+dogs:set("Tom", 32)
+print(dogs:get("Tom"))
+
+local cats = ngx.shared.cats
+dogs:set("Max", 64)
+print(dogs:get("Max"))
+--- out
+32
+64
+--- err
+
+
+
+=== TEST 13: multiple -e options
 --- opts: -e 'print(1)' -e 'print(2)'
 --- out
 1
@@ -197,7 +229,7 @@ bar: 56
 
 
 
-=== TEST 13: multiple -e options with file
+=== TEST 14: multiple -e options with file
 --- opts: -e 'print(1)' -e 'print(2)'
 --- src
 print(3)


### PR DESCRIPTION
Hey, 

Another change, this time motivated by the use of a lua-resty module in a resty-cli script that requires an shm entry in the Nginx config.

Using `http-include` would be quite more painful in my case than to simply create an shm entry via a CLI argument. So I thought: why not allowing any ngx_lua directives to be given like so, and not just shms? My reasoning is that it would not lead to more user errors than specifying wrong entries in an included file anyways. That might be overlooking some limitations as to why this wasn't already implemented?

Let me know what you think.