### PR TITLE
feat: implement --shdict to create shared dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Synopsis
 
         --resolve-ipv6      Make the nginx resolver lookup both IPv4 and IPv6 addresses
 
-        --shdict            Create the specified lua shared dicts in the http
+        --shdict NAME       Create the specified lua shared dicts in the http
                             configuration block (multiple instances are supported).
 
         --nginx             Specify the nginx path (this option might be removed in the future).

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Synopsis
 
         --resolve-ipv6      Make the nginx resolver lookup both IPv4 and IPv6 addresses
 
+        --shdict            Create the specified lua shared dicts in the http
+                            configuration block (multiple instances are supported).
+
         --nginx             Specify the nginx path (this option might be removed in the future).
         -V                  Print version numbers and nginx configurations.
         --valgrind          Use valgrind to run nginx
@@ -120,6 +123,13 @@ User command-line arguments are also passed:
 
     $ resty -e 'print(arg[1], ", ", arg[2])' hello world
     hello, world
+
+If you need to use a shared dict:
+
+    $ resty --shdict='dogs 1m' -e 'local dict = ngx.shared.dogs
+                                   dict:set("Tom", 56)
+                                   print(dict:get("Tom"))'
+    56
 
 To check version numbers:
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Synopsis
 
         --resolve-ipv6      Make the nginx resolver lookup both IPv4 and IPv6 addresses
 
-        --shdict NAME       Create the specified lua shared dicts in the http
+        --shdict NAME SIZE  Create the specified lua shared dicts in the http
                             configuration block (multiple instances are supported).
 
         --nginx             Specify the nginx path (this option might be removed in the future).

--- a/bin/resty
+++ b/bin/resty
@@ -30,14 +30,23 @@ sub resolve_includes {
     return join("\n", @paths);
 }
 
+sub format_directives {
+    my $name = shift;
+    my @directives = map {
+        "$name $_;";
+    } @_;
+    return join("\n", @directives);
+}
+
 my @all_args = @ARGV;
 
-my (@http_includes, @main_includes, @src_a);
+my (@http_includes, @main_includes, @shdicts, @src_a);
 
 GetOptions("c=i",             \(my $conns_num),
            "e=s",             \@src_a,
            "h|help",          \(my $help),
            "http-include=s",  \@http_includes,
+           "shdict=s",        \@shdicts,
            "I=s@",            \(my $Inc),
            "main-include=s",  \@main_includes,
            "nginx=s",         \(my $nginx_path),
@@ -213,6 +222,7 @@ for my $var (sort keys %ENV) {
 
 my $main_include_directives = resolve_includes('main', @main_includes);
 my $http_include_directives = resolve_includes('http', @http_includes);
+my $lua_shared_dicts = format_directives('lua_shared_dict', @shdicts);
 
 my $conf_file = File::Spec->catfile($conf_dir, "nginx.conf");
 open my $out, ">$conf_file"
@@ -239,6 +249,7 @@ http {
     access_log off;
     lua_socket_log_errors off;
     resolver @nameservers;
+    $lua_shared_dicts
 $lua_package_path_config
     $http_include_directives
     init_by_lua_block {
@@ -418,6 +429,9 @@ Options:
                         (multiple instances are supported).
 
     --resolve-ipv6      Make the nginx resolver lookup both IPv4 and IPv6 addresses
+
+    --shdict            Create the specified lua shared dicts in the http
+                        configuration block (multiple instances are supported).
 
     --nginx             Specify the nginx path (this option might be removed in the future).
     -V                  Print version numbers and nginx configurations.

--- a/bin/resty
+++ b/bin/resty
@@ -38,6 +38,16 @@ sub format_directives {
     return join("\n", @directives);
 }
 
+sub check_arg_format {
+    my ($arg_name, $regex, $arg_format, @args) = @_;
+    for (@args) {
+        unless (m/$regex/) {
+            warn "Invalid value for $arg_name option. Expected: $arg_format\n";
+            exit(2);
+        }
+    }
+}
+
 my @all_args = @ARGV;
 
 my (@http_includes, @main_includes, @shdicts, @src_a);
@@ -55,6 +65,8 @@ GetOptions("c=i",             \(my $conns_num),
            "resolve-ipv6",    \(my $resolve_ipv6),
            "V|v",             \(my $version))
    or usage(1);
+
+check_arg_format('--shdict', qr/^[a-z]*\s\d+(?i)[km]$/, 'NAME SIZE', @shdicts);
 
 my $src;
 if (@src_a) {

--- a/bin/resty
+++ b/bin/resty
@@ -38,12 +38,11 @@ sub format_directives {
     return join("\n", @directives);
 }
 
-sub check_arg_format {
-    my ($arg_name, $regex, $arg_format, @args) = @_;
-    for (@args) {
+sub check_option_format {
+    my ($opt_name, $regex, $opt_format, $args_ref) = @_;
+    for (@$args_ref) {
         unless (m/$regex/) {
-            warn "Invalid value for $arg_name option. Expected: $arg_format\n";
-            exit(2);
+            die "Invalid value for $opt_name option. Expected: $opt_format\n";
         }
     }
 }
@@ -66,7 +65,7 @@ GetOptions("c=i",             \(my $conns_num),
            "V|v",             \(my $version))
    or usage(1);
 
-check_arg_format('--shdict', qr/^[a-z]*\s\d+(?i)[km]$/, 'NAME SIZE', @shdicts);
+check_option_format('--shdict', qr/^[_a-z]+\s+\d+(?i)[km]?\z/, 'NAME SIZE', \@shdicts);
 
 my $src;
 if (@src_a) {

--- a/bin/resty
+++ b/bin/resty
@@ -430,7 +430,7 @@ Options:
 
     --resolve-ipv6      Make the nginx resolver lookup both IPv4 and IPv6 addresses
 
-    --shdict NAME       Create the specified lua shared dicts in the http
+    --shdict NAME SIZE  Create the specified lua shared dicts in the http
                         configuration block (multiple instances are supported).
 
     --nginx             Specify the nginx path (this option might be removed in the future).

--- a/bin/resty
+++ b/bin/resty
@@ -430,7 +430,7 @@ Options:
 
     --resolve-ipv6      Make the nginx resolver lookup both IPv4 and IPv6 addresses
 
-    --shdict            Create the specified lua shared dicts in the http
+    --shdict NAME       Create the specified lua shared dicts in the http
                         configuration block (multiple instances are supported).
 
     --nginx             Specify the nginx path (this option might be removed in the future).

--- a/t/resty/options.t
+++ b/t/resty/options.t
@@ -54,7 +54,7 @@ Options:
 
     --resolve-ipv6      Make the nginx resolver lookup both IPv4 and IPv6 addresses
 
-    --shdict NAME       Create the specified lua shared dicts in the http
+    --shdict NAME SIZE  Create the specified lua shared dicts in the http
                         configuration block (multiple instances are supported).
 
     --nginx             Specify the nginx path (this option might be removed in the future).

--- a/t/resty/options.t
+++ b/t/resty/options.t
@@ -222,7 +222,40 @@ print(dogs:get("Max"))
 
 
 
-=== TEST 14: multiple -e options
+=== TEST 14: --shdict option missing size
+--- opts: '--shdict=dogs'
+--- out
+--- err
+Invalid value for --shdict option. Expected: NAME SIZE
+--- ret: 2
+
+
+
+=== TEST 15: --shdict option case-insensitive size (1/2)
+--- opts: '--shdict=dogs 1m'
+--- src
+local dogs = ngx.shared.dogs
+dogs:set("Tom", 32)
+print(dogs:get("Tom"))
+--- out
+32
+--- err
+
+
+
+=== TEST 16: --shdict option case-insensitive size (2/2)
+--- opts: '--shdict=dogs 1M'
+--- src
+local dogs = ngx.shared.dogs
+dogs:set("Tom", 32)
+print(dogs:get("Tom"))
+--- out
+32
+--- err
+
+
+
+=== TEST 17: multiple -e options
 --- opts: -e 'print(1)' -e 'print(2)'
 --- out
 1
@@ -231,7 +264,7 @@ print(dogs:get("Max"))
 
 
 
-=== TEST 15: multiple -e options with file
+=== TEST 18: multiple -e options with file
 --- opts: -e 'print(1)' -e 'print(2)'
 --- src
 print(3)
@@ -243,7 +276,7 @@ print(3)
 
 
 
-=== TEST 16: multiple -e options with single quotes
+=== TEST 19: multiple -e options with single quotes
 --- opts: -e "print('1')" -e 'print(2)'
 --- out
 1
@@ -252,7 +285,7 @@ print(3)
 
 
 
-=== TEST 17: resolver has ipv6=off by default
+=== TEST 20: resolver has ipv6=off by default
 --- src
 local prefix = ngx.config.prefix()
 local conf = prefix.."conf/nginx.conf"
@@ -266,7 +299,7 @@ resolver [\s\S]* ipv6=off;
 
 
 
-=== TEST 18: --resolve-ipv6 flag enables ipv6 resolution
+=== TEST 21: --resolve-ipv6 flag enables ipv6 resolution
 --- opts: --resolve-ipv6
 --- src
 local prefix = ngx.config.prefix()

--- a/t/resty/options.t
+++ b/t/resty/options.t
@@ -54,6 +54,9 @@ Options:
 
     --resolve-ipv6      Make the nginx resolver lookup both IPv4 and IPv6 addresses
 
+    --shdict            Create the specified lua shared dicts in the http
+                        configuration block (multiple instances are supported).
+
     --nginx             Specify the nginx path (this option might be removed in the future).
     -V                  Print version numbers and nginx configurations.
     --valgrind          Use valgrind to run nginx
@@ -190,7 +193,36 @@ bar: 56
 
 
 
-=== TEST 12: multiple -e options
+=== TEST 12: --shdict option
+--- opts: '--shdict=dogs 12k'
+--- src
+local dogs = ngx.shared.dogs
+dogs:set("Tom", 32)
+print(dogs:get("Tom"))
+--- out
+32
+--- err
+
+
+
+=== TEST 13: multiple --shdict option
+--- opts: '--shdict=dogs 1m' '--shdict=cats 1m'
+--- src
+local dogs = ngx.shared.dogs
+dogs:set("Tom", 32)
+print(dogs:get("Tom"))
+
+local cats = ngx.shared.cats
+dogs:set("Max", 64)
+print(dogs:get("Max"))
+--- out
+32
+64
+--- err
+
+
+
+=== TEST 14: multiple -e options
 --- opts: -e 'print(1)' -e 'print(2)'
 --- out
 1
@@ -199,7 +231,7 @@ bar: 56
 
 
 
-=== TEST 13: multiple -e options with file
+=== TEST 15: multiple -e options with file
 --- opts: -e 'print(1)' -e 'print(2)'
 --- src
 print(3)
@@ -211,7 +243,7 @@ print(3)
 
 
 
-=== TEST 14: multiple -e options with single quotes
+=== TEST 16: multiple -e options with single quotes
 --- opts: -e "print('1')" -e 'print(2)'
 --- out
 1
@@ -220,7 +252,7 @@ print(3)
 
 
 
-=== TEST 15: resolver has ipv6=off by default
+=== TEST 17: resolver has ipv6=off by default
 --- src
 local prefix = ngx.config.prefix()
 local conf = prefix.."conf/nginx.conf"
@@ -234,7 +266,7 @@ resolver [\s\S]* ipv6=off;
 
 
 
-=== TEST 16: --resolve-ipv6 flag enables ipv6 resolution
+=== TEST 18: --resolve-ipv6 flag enables ipv6 resolution
 --- opts: --resolve-ipv6
 --- src
 local prefix = ngx.config.prefix()

--- a/t/resty/options.t
+++ b/t/resty/options.t
@@ -227,7 +227,7 @@ print(dogs:get("Max"))
 --- out
 --- err
 Invalid value for --shdict option. Expected: NAME SIZE
---- ret: 2
+--- ret: 255
 
 
 
@@ -255,7 +255,19 @@ print(dogs:get("Tom"))
 
 
 
-=== TEST 17: multiple -e options
+=== TEST 17: --shdict option permissive format
+--- opts: '--shdict=cats_dogs   20000'
+--- src
+local dict = ngx.shared.cats_dogs
+dict:set("Tom", 32)
+print(dict:get("Tom"))
+--- out
+32
+--- err
+
+
+
+=== TEST 18: multiple -e options
 --- opts: -e 'print(1)' -e 'print(2)'
 --- out
 1
@@ -264,7 +276,7 @@ print(dogs:get("Tom"))
 
 
 
-=== TEST 18: multiple -e options with file
+=== TEST 19: multiple -e options with file
 --- opts: -e 'print(1)' -e 'print(2)'
 --- src
 print(3)
@@ -276,7 +288,7 @@ print(3)
 
 
 
-=== TEST 19: multiple -e options with single quotes
+=== TEST 20: multiple -e options with single quotes
 --- opts: -e "print('1')" -e 'print(2)'
 --- out
 1
@@ -285,7 +297,7 @@ print(3)
 
 
 
-=== TEST 20: resolver has ipv6=off by default
+=== TEST 21: resolver has ipv6=off by default
 --- src
 local prefix = ngx.config.prefix()
 local conf = prefix.."conf/nginx.conf"
@@ -299,7 +311,7 @@ resolver [\s\S]* ipv6=off;
 
 
 
-=== TEST 21: --resolve-ipv6 flag enables ipv6 resolution
+=== TEST 22: --resolve-ipv6 flag enables ipv6 resolution
 --- opts: --resolve-ipv6
 --- src
 local prefix = ngx.config.prefix()

--- a/t/resty/options.t
+++ b/t/resty/options.t
@@ -54,7 +54,7 @@ Options:
 
     --resolve-ipv6      Make the nginx resolver lookup both IPv4 and IPv6 addresses
 
-    --shdict            Create the specified lua shared dicts in the http
+    --shdict NAME       Create the specified lua shared dicts in the http
                         configuration block (multiple instances are supported).
 
     --nginx             Specify the nginx path (this option might be removed in the future).


### PR DESCRIPTION
Updated version of #11, as a new PR because of the semantic changes.

This implements an `--shdict` option, as previously discussed. It leaves the room open to including other ngx_lua directives (including ones with potentially multiple occurrences).
