### PR TITLE
feat(resty) disable IPv6 resolution by default and introduce an --ipv6 flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Synopsis
         --main-include path Include the specified file in the nginx main configuration block
                             (multiple instances are supported).
 
+        --resolve-ipv6      Make the nginx resolver lookup both IPv4 and IPv6 addresses
+
         --nginx             Specify the nginx path (this option might be removed in the future).
         -V                  Print version numbers and nginx configurations.
         --valgrind          Use valgrind to run nginx

--- a/bin/resty
+++ b/bin/resty
@@ -43,7 +43,7 @@ GetOptions("c=i",             \(my $conns_num),
            "nginx=s",         \(my $nginx_path),
            "valgrind",        \(my $use_valgrind),
            "valgrind-opts=s", \(my $valgrind_opts),
-           "no-ipv6",         \(my $no_ipv6),
+           "ipv6",            \(my $ipv6),
            "V|v",             \(my $version))
    or die usage(1);
 
@@ -109,11 +109,15 @@ my $conns = $conns_num || 64;
 
 my @nameservers;
 
+if (!$ipv6) {
+    unshift @nameservers, "ipv6=off";
+}
+
 # try to read the nameservers used by the system resolver:
 if (open my $in, "/etc/resolv.conf") {
     while (<$in>) {
         if (/^\s*nameserver\s+(\d+(?:\.\d+){3})(?:\s+|$)/) {
-            push @nameservers, $1;
+            unshift @nameservers, $1;
             if (@nameservers > 10) {
                 last;
             }
@@ -124,11 +128,7 @@ if (open my $in, "/etc/resolv.conf") {
 
 if (!@nameservers) {
     # default to Google's open DNS servers
-    push @nameservers, "8.8.8.8", "8.8.4.4";
-}
-
-if ($no_ipv6) {
-    push @nameservers, "ipv6=off";
+    unshift @nameservers, "8.8.8.8", "8.8.4.4";
 }
 
 #warn "@nameservers\n";
@@ -412,7 +412,7 @@ Options:
     --main-include path Include the specified file in the nginx main configuration block
                         (multiple instances are supported).
 
-    -no-ipv6            Prevents the nginx resolver to lookup IPv6 addresses
+    --ipv6              Make the nginx resolver lookup both IPv4 and IPv6 addresses
 
     --nginx             Specify the nginx path (this option might be removed in the future).
     -V                  Print version numbers and nginx configurations.

--- a/bin/resty
+++ b/bin/resty
@@ -43,6 +43,7 @@ GetOptions("c=i",             \(my $conns_num),
            "nginx=s",         \(my $nginx_path),
            "valgrind",        \(my $use_valgrind),
            "valgrind-opts=s", \(my $valgrind_opts),
+           "no-ipv6",         \(my $no_ipv6),
            "V|v",             \(my $version))
    or die usage(1);
 
@@ -124,6 +125,10 @@ if (open my $in, "/etc/resolv.conf") {
 if (!@nameservers) {
     # default to Google's open DNS servers
     push @nameservers, "8.8.8.8", "8.8.4.4";
+}
+
+if ($no_ipv6) {
+    push @nameservers, "ipv6=off";
 }
 
 #warn "@nameservers\n";
@@ -406,6 +411,8 @@ Options:
 
     --main-include path Include the specified file in the nginx main configuration block
                         (multiple instances are supported).
+
+    -no-ipv6            Prevents the nginx resolver to lookup IPv6 addresses
 
     --nginx             Specify the nginx path (this option might be removed in the future).
     -V                  Print version numbers and nginx configurations.

--- a/bin/resty
+++ b/bin/resty
@@ -43,7 +43,7 @@ GetOptions("c=i",             \(my $conns_num),
            "nginx=s",         \(my $nginx_path),
            "valgrind",        \(my $use_valgrind),
            "valgrind-opts=s", \(my $valgrind_opts),
-           "ipv6",            \(my $ipv6),
+           "resolve-ipv6",    \(my $resolve_ipv6),
            "V|v",             \(my $version))
    or die usage(1);
 
@@ -109,7 +109,7 @@ my $conns = $conns_num || 64;
 
 my @nameservers;
 
-if (!$ipv6) {
+if (!$resolve_ipv6) {
     unshift @nameservers, "ipv6=off";
 }
 
@@ -412,7 +412,7 @@ Options:
     --main-include path Include the specified file in the nginx main configuration block
                         (multiple instances are supported).
 
-    --ipv6              Make the nginx resolver lookup both IPv4 and IPv6 addresses
+    --resolve-ipv6      Make the nginx resolver lookup both IPv4 and IPv6 addresses
 
     --nginx             Specify the nginx path (this option might be removed in the future).
     -V                  Print version numbers and nginx configurations.

--- a/t/lib/Test/Resty.pm
+++ b/t/lib/Test/Resty.pm
@@ -124,12 +124,19 @@ sub run_test ($) {
         is $out, $block->out, "$name - stdout eq okay";
     }
 
-    my $regex = $block->out_like;
-    if (defined $regex) {
+    my $regex;
+    if (defined $block->out_like) {
+        $regex = $block->out_like;
         if (!ref $regex) {
             $regex = qr/$regex/ms;
         }
         like $out, $regex, "$name - stdout like okay";
+    } elsif (defined $block->out_not_like) {
+        $regex = $block->out_not_like;
+        if (!ref $regex) {
+            $regex = qr/$regex/ms;
+        }
+        unlike $out, $regex, "$name - stdout unlike okay";
     }
 
     if (defined $block->err) {

--- a/t/lib/Test/Resty.pm
+++ b/t/lib/Test/Resty.pm
@@ -131,6 +131,7 @@ sub run_test ($) {
             $regex = qr/$regex/ms;
         }
         like $out, $regex, "$name - stdout like okay";
+
     } elsif (defined $block->out_not_like) {
         $regex = $block->out_not_like;
         if (!ref $regex) {

--- a/t/resty/options.t
+++ b/t/resty/options.t
@@ -52,7 +52,7 @@ Options:
     --main-include path Include the specified file in the nginx main configuration block
                         (multiple instances are supported).
 
-    -no-ipv6            Prevents the nginx resolver to lookup IPv6 addresses
+    --ipv6              Make the nginx resolver lookup both IPv4 and IPv6 addresses
 
     --nginx             Specify the nginx path (this option might be removed in the future).
     -V                  Print version numbers and nginx configurations.
@@ -220,8 +220,7 @@ print(3)
 
 
 
-=== TEST 15: --no-ipv6 flag
---- opts: --no-ipv6
+=== TEST 15: resolver has ipv6=off by default
 --- src
 local prefix = ngx.config.prefix()
 local conf = prefix.."conf/nginx.conf"
@@ -230,5 +229,20 @@ local str = f:read("*a")
 f:close()
 print(str)
 --- out_like
+resolver [\s\S]* ipv6=off;
+--- err
+
+
+
+=== TEST 16: --ipv6 flag enables ipv6 resolution
+--- opts: --ipv6
+--- src
+local prefix = ngx.config.prefix()
+local conf = prefix.."conf/nginx.conf"
+local f = assert(io.open(conf, "r"))
+local str = f:read("*a")
+f:close()
+print(str)
+--- out_not_like
 resolver [\s\S]* ipv6=off;
 --- err

--- a/t/resty/options.t
+++ b/t/resty/options.t
@@ -52,7 +52,7 @@ Options:
     --main-include path Include the specified file in the nginx main configuration block
                         (multiple instances are supported).
 
-    --ipv6              Make the nginx resolver lookup both IPv4 and IPv6 addresses
+    --resolve-ipv6      Make the nginx resolver lookup both IPv4 and IPv6 addresses
 
     --nginx             Specify the nginx path (this option might be removed in the future).
     -V                  Print version numbers and nginx configurations.
@@ -234,8 +234,8 @@ resolver [\s\S]* ipv6=off;
 
 
 
-=== TEST 16: --ipv6 flag enables ipv6 resolution
---- opts: --ipv6
+=== TEST 16: --resolve-ipv6 flag enables ipv6 resolution
+--- opts: --resolve-ipv6
 --- src
 local prefix = ngx.config.prefix()
 local conf = prefix.."conf/nginx.conf"

--- a/t/resty/options.t
+++ b/t/resty/options.t
@@ -52,6 +52,8 @@ Options:
     --main-include path Include the specified file in the nginx main configuration block
                         (multiple instances are supported).
 
+    -no-ipv6            Prevents the nginx resolver to lookup IPv6 addresses
+
     --nginx             Specify the nginx path (this option might be removed in the future).
     -V                  Print version numbers and nginx configurations.
     --valgrind          Use valgrind to run nginx
@@ -214,4 +216,19 @@ print(3)
 --- out
 1
 2
+--- err
+
+
+
+=== TEST 15: --no-ipv6 flag
+--- opts: --no-ipv6
+--- src
+local prefix = ngx.config.prefix()
+local conf = prefix.."conf/nginx.conf"
+local f = assert(io.open(conf, "r"))
+local str = f:read("*a")
+f:close()
+print(str)
+--- out_like
+resolver [\s\S]* ipv6=off;
 --- err


### PR DESCRIPTION
Handy when scripting with cosockets and if we don't want those to
attempt a connection through IPv6.
