### PR TITLE
add other signal handler for more use cases

### DIFF
--- a/bin/resty
+++ b/bin/resty
@@ -360,13 +360,18 @@ if ($use_valgrind) {
 
 my $child_pid;
 
-sub sigint {
-    $SIG{INT} = \&sigint;
+sub forward_signal {
+    my $signame = shift;
+
     if ($child_pid) {
-        kill INT => $child_pid;
+        kill $signame => $child_pid
+            or die "failed to send $signame to process $child_pid: $!";
     }
 }
-$SIG{INT} = \&sigint;
+
+for my $sig (qw/ INT TERM QUIT HUP USR1 USR2 WINCH /) {
+    $SIG{$sig} = \&forward_signal;
+}
 
 my $pid = fork();
 

--- a/t/lib/Test/Resty.pm
+++ b/t/lib/Test/Resty.pm
@@ -87,6 +87,18 @@ sub run_test ($) {
         $cmd .= " $luafile"
     }
 
+    my $binfile;
+    if (defined $block->mock_nginx) {
+        my ($out, $binfile) = tempfile("testXXXXXX",
+                                        SUFFIX => '',
+                                        TMPDIR => 1,
+                                        UNLINK => 1);
+        print $out ($block->mock_nginx);
+        close $out;
+        chmod 0755, $binfile;
+        $cmd .= " --nginx $binfile"
+    }
+
     if (defined $args) {
         $cmd .= " $args";
     }
@@ -109,7 +121,7 @@ sub run_test ($) {
             if (!defined $block->expect_timeout) {
                 fail("$name: resty process timed out");
             }
-	} else {
+        } else {
             fail("$name: failed to run command [$cmd]: $@");
         }
     }

--- a/t/resty/signals.t
+++ b/t/resty/signals.t
@@ -1,0 +1,184 @@
+# vi:ft= et ts=4 sw=4
+
+use lib 't/lib';
+use Test::Resty;
+
+plan tests => blocks() * 3;
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: Forward SIGINT to child process
+--- opts: -e 'print(1)'
+--- mock_nginx
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+$SIG{INT}   = sub { print "GOT SIGINT"; exit 0 };
+$SIG{HUP}   = sub { print "GOT SIGHUP"; exit 0 };
+$SIG{WINCH} = sub { print "GOT SIGWINCH"; exit 0 };
+
+my $ppid;
+$ppid = getppid();
+while (1) {
+    kill INT => $ppid;
+    sleep(1);
+}
+
+--- out_like chop
+SIGINT
+
+--- err
+
+
+
+=== TEST 2: Forward SIGHUP to child process
+--- opts: -e 'print(1)'
+--- mock_nginx
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+$SIG{INT}   = sub { print "GOT SIGINT"; exit 0 };
+$SIG{HUP}   = sub { print "GOT SIGHUP"; exit 0 };
+$SIG{WINCH} = sub { print "GOT SIGWINCH"; exit 0 };
+
+my $ppid;
+$ppid = getppid();
+while (1) {
+    kill HUP => $ppid;
+    sleep(1);
+}
+
+--- out_like chop
+SIGHUP
+
+--- err
+
+
+
+=== TEST 3: Forward SIGTERM to child process
+--- opts: -e 'print(1)'
+--- mock_nginx
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+$SIG{TERM}  = sub { print "GOT SIGTERM"; exit 0 };
+$SIG{QUIT}  = sub { print "GOT SIGQUIT"; exit 0 };
+$SIG{USR1}  = sub { print "GOT SIGUSR1"; exit 0 };
+
+my $ppid;
+$ppid = getppid();
+while (1) {
+    kill TERM => $ppid;
+    sleep(1);
+}
+
+--- out_like chop
+SIGTERM
+
+--- err
+
+
+
+=== TEST 4: Forward SIGQUIT to child process
+--- opts: -e 'print(1)'
+--- mock_nginx
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+$SIG{QUIT}  = sub { print "GOT SIGQUIT"; exit 0 };
+$SIG{USR1}  = sub { print "GOT SIGUSR1"; exit 0 };
+$SIG{USR2}  = sub { print "GOT SIGUSR2"; exit 0 };
+
+my $ppid;
+$ppid = getppid();
+while (1) {
+    kill QUIT => $ppid;
+    sleep(1);
+}
+
+--- out_like chop
+SIGQUIT
+
+--- err
+
+
+
+=== TEST 5: Forward SIGUSR1 to child process
+--- opts: -e 'print(1)'
+--- mock_nginx
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+$SIG{QUIT}  = sub { print "GOT SIGQUIT"; exit 0 };
+$SIG{USR1}  = sub { print "GOT SIGUSR1"; exit 0 };
+$SIG{USR2}  = sub { print "GOT SIGUSR2"; exit 0 };
+
+my $ppid;
+$ppid = getppid();
+while (1) {
+    kill USR1 => $ppid;
+    sleep(1);
+}
+
+--- out_like chop
+SIGUSR1
+
+--- err
+
+
+
+=== TEST 6: Forward SIGUSR2 to child process
+--- opts: -e 'print(1)'
+--- mock_nginx
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+$SIG{USR1}  = sub { print "GOT SIGUSR1"; exit 0 };
+$SIG{USR2}  = sub { print "GOT SIGUSR2"; exit 0 };
+$SIG{WINCH} = sub { print "GOT SIGWINCH"; exit 0 };
+
+my $ppid;
+$ppid = getppid();
+while (1) {
+    kill USR2 => $ppid;
+    sleep(1);
+}
+
+--- out_like chop
+SIGUSR2
+
+--- err
+
+
+
+=== TEST 7: Forward SIGUSR2 to child process
+--- opts: -e 'print(1)'
+--- mock_nginx
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+$SIG{INT}   = sub { print "GOT SIGINT"; exit 0 };
+$SIG{HUP}   = sub { print "GOT SIGHUP"; exit 0 };
+$SIG{WINCH} = sub { print "GOT SIGWINCH"; exit 0 };
+
+my $ppid;
+$ppid = getppid();
+while (1) {
+    kill WINCH => $ppid;
+    sleep(1);
+}
+
+--- out_like chop
+SIGWINCH
+
+--- err
+


### PR DESCRIPTION
Hi @agentzh ,

I add some other signal handlers into the `resty-cli`. The main reason I do that is let `resty` forward the signal to the actual child process(`nginx`) correctly.

### Use cases

I am writing an application using `resty-cli` as my application cli entry point. For example:

```lua
!#/path/to/resty

do_some_prev_steps()

local children = {
  fork_a_new_nginx() -- returns a pid
}

local function forward_fn(sig)
  for _, ch_pid in ipairs(children) do
    sig.kill(ch_pid, sig)
  end
end

register_signal_handlers(forward_fn)
```

### Current behavior

When I do `kill -HUP <resty_pid>`. Currently the process will hangup rather than forward the
signal to the child process. Same as other signals.

### Changes

This PR is adding other signals which nginx is listening to. Which including:

```
SIGTERM,
SIGHUP,
SIGUSR1,
SIGUSE2,
SIGWINCH,
SIGQUIT
```

### Benefits

When using the resty-cli in docker. The lua script will be able to correctly get the signal from
the docker daemon and do some cleanup. For example, SIGTERM when try to run docker kill. Or SIGHUP when try to reload the nginx configuration without causing any downtime :).
