### PR TITLE
bugfix: don't add "ipv6=off" if Nginx is not compiled with IPv6 support

### DIFF
--- a/bin/resty
+++ b/bin/resty
@@ -130,7 +130,15 @@ my $conns = $conns_num || 64;
 my @nameservers;
 
 if (!$resolve_ipv6) {
-    unshift @nameservers, "ipv6=off";
+    # no error check to let the later exec() fail.
+    # worst case: ipv6=off is not added to the nginx
+    # conf, but the worker won't spawn anyways...
+    my $stderr = `$nginx_path -V 2>&1 1>/dev/null`;
+    #warn $stderr;
+
+    if (index($stderr, "--with-ipv6") != -1) {
+        unshift @nameservers, "ipv6=off";
+    }
 }
 
 # try to read the nameservers used by the system resolver:

--- a/t/fixtures/nginx
+++ b/t/fixtures/nginx
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ "$1" = "-V" ]]; then
+    nginx -V 3>&1 1>&2 2>&3 3>&- | sed 's/--with-ipv6//g'
+    exit 0
+fi
+
+nginx "$@"
+

--- a/t/resty/options.t
+++ b/t/resty/options.t
@@ -324,3 +324,18 @@ print(str)
 --- out_not_like
 resolver [\s\S]* ipv6=off;
 --- err
+
+
+
+=== TEST 23: ignore no ipv6 flag if Nginx doesn't support ipv6
+--- opts: --nginx=t/fixtures/nginx
+--- src
+local prefix = ngx.config.prefix()
+local conf = prefix.."conf/nginx.conf"
+local f = assert(io.open(conf, "r"))
+local str = f:read("*a")
+f:close()
+print(str)
+--- out_not_like
+resolver [\s\S]* ipv6=off;
+--- err


### PR DESCRIPTION
This is a proposed solution for #19.

This patch does not test that `nginx -V` returns a valid exit code for 2 reasons:
- since `nginx -V` is now being run every time, we'd rather wait for the later `exec("nginx -p <...> -c <...>")` to report a failure. The worst case scenario caused by ignoring this error will be that `ipv6=off` won't be added to `nginx.conf`, which won't matter since the worker won't be spawned, and the error will be properly reported by the `exec()` call.
- If we do the following:
```perl
my $stderr = `nginx -V 2>&1 1>/dev/null`;
if ($? != 0) {
    die "Failed to run command \"$cmd\": $stderr\n";
}
```

The call to `die()` makes resty-cli return `127` as an exit code and `stderr` is taken from the spawned `sh` shell. Both of those values are currently tested for in `TEST 1: bad --nginx value`, and expecting different results would introduce breaking changes. The `resty/signals.t` tests would fail as well.

I believe this is the most conservative way to fix this issue.