### PR TITLE
bugfix: propagate return value as the exit code

### DIFF
--- a/bin/resty
+++ b/bin/resty
@@ -219,8 +219,10 @@ $inline_lua
 $file_lua
 
                 gen = function()
-                  if inline_gen then inline_gen() end
-                  if file_gen then file_gen() end
+                  local rc
+                  if inline_gen then rc = inline_gen() end
+                  if file_gen then rc = file_gen() end
+                  return rc
                 end
             end
 _EOC_

--- a/t/resty/sanity.t
+++ b/t/resty/sanity.t
@@ -1,0 +1,27 @@
+# vi:ft= et ts=4 sw=4
+
+use lib 't/lib';
+use Test::Resty;
+
+plan tests => blocks() * 2;
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: exits with return value
+--- src
+print("hello world")
+return 6
+--- out
+hello world
+--- ret: 6
+
+
+
+=== TEST 2: errors out when return value is not a number
+--- src
+return "hello"
+--- err_like chop
+bad return value of type string
+--- ret: 1


### PR DESCRIPTION
If that behavior is still desired, then it seems we were not correctly propagating the return value from the user script as our exit code, although the code seems to be trying to do it:
```lua
local rc = err
if rc and type(rc) ~= "number" then
  return handle_err("bad return value of type " .. type(rc))
end
return exit(rc)
```