### PR TITLE
feature: provide stacktraces for user errors

### DIFF
--- a/bin/resty
+++ b/bin/resty
@@ -219,8 +219,8 @@ $inline_lua
 $file_lua
 
                 gen = function()
-                  if inline_gen then return inline_gen() end
-                  if file_gen then return file_gen() end
+                  if inline_gen then inline_gen() end
+                  if file_gen then file_gen() end
                 end
             end
 _EOC_
@@ -349,7 +349,9 @@ $loader
             -- print("calling timer.at...")
             local ok, err = ngx.timer.at(0, function ()
                 -- io.stderr:write("timer firing")
-                local ok, err = xpcall(gen, function(err)
+                local ok, err = xpcall(gen, function (err)
+                    -- level 3: we skip this function and the
+                    -- error() call itself in our stacktrace
                     local trace = debug.traceback(err, 3)
                     return handle_err(trace)
                 end)

--- a/bin/resty
+++ b/bin/resty
@@ -219,8 +219,8 @@ $inline_lua
 $file_lua
 
                 gen = function()
-                  if inline_gen then inline_gen() end
-                  if file_gen then file_gen() end
+                  if inline_gen then return inline_gen() end
+                  if file_gen then return file_gen() end
                 end
             end
 _EOC_
@@ -349,10 +349,10 @@ $loader
             -- print("calling timer.at...")
             local ok, err = ngx.timer.at(0, function ()
                 -- io.stderr:write("timer firing")
-                local ok, err = pcall(gen)
-                if not ok then
-                    return handle_err(err)
-                end
+                local ok, err = xpcall(gen, function(err)
+                    local trace = debug.traceback(err, 3)
+                    return handle_err(trace)
+                end)
                 local rc = err
                 if rc and type(rc) ~= "number" then
                     return handle_err("bad return value of type " .. type(rc))

--- a/t/resty/sanity.t
+++ b/t/resty/sanity.t
@@ -25,7 +25,8 @@ g()
 stack traceback:
 .*?\.lua:2: in function 'f'
 .*?\.lua:6: in function 'g'
-.*?\.lua:9: in main chunk
+.*?\.lua:\d+: in function 'file_gen'
+.*?init_worker_by_lua:\d+: in function <init_worker_by_lua:\d+>
 .*?\[C\]: in function 'xpcall'
 .*?init_worker_by_lua:\d+: in function <init_worker_by_lua:\d+>$
 --- ret: 1

--- a/t/resty/sanity.t
+++ b/t/resty/sanity.t
@@ -1,0 +1,31 @@
+# vi:ft= et ts=4 sw=4
+
+use lib 't/lib';
+use Test::Resty;
+
+plan tests => blocks() * 2;
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: provides stacktrace on user errors
+--- src
+local function f()
+    error("something went wrong")
+end
+
+local function g()
+    f()
+end
+
+g()
+--- err_like chomp
+^.*?\.lua:\d+: something went wrong
+stack traceback:
+.*?\.lua:2: in function 'f'
+.*?\.lua:6: in function 'g'
+.*?\.lua:9: in main chunk
+.*?\[C\]: in function 'xpcall'
+.*?init_worker_by_lua:\d+: in function <init_worker_by_lua:\d+>$
+--- ret: 1


### PR DESCRIPTION
Following openresty/lua-nginx-module#951, which raised concerns about not logging calls to `error()`. I assume that "not logging" meant "not logging stacktraces", but I would like to have @bungle's confirmation on that.

This patch also allows us to behave slightly closer to the Lua/LuaJIT interpreters.

Assuming test.lua:
```lua
local function f()
    error("oops")
end

local function g()
    f()
end

g()
```

We get this result for LuaJIT and the current version of resty-cli:
```
$ luajit test.lua
luajit: test.lua:2: oops
stack traceback:
	[C]: in function 'error'
	test.lua:2: in function 'f'
	test.lua:6: in function 'g'
	test.lua:9: in main chunk
	[C]: at 0x0100001540
$ resty test.lua
test.lua:2: oops
```

With this patch, resty-cli gives us:
```
$ resty test.lua
test.lua:2: oops
stack traceback:
	test.lua:2: in function 'f'
	test.lua:6: in function 'g'
	test.lua:9: in main chunk
	[C]: in function 'xpcall'
	init_worker_by_lua:43: in function <init_worker_by_lua:41>
```

Which will allow users to better trace their errors along the call stack.

One thing this doesn't support though, is the use of a level argument in `error()`, as such:
```lua
local function f()
  error("oops", 2)
end
```

The stacktrace will remain the same:
```
$ resty test.lua
test.lua:2: oops
stack traceback:
	test.lua:2: in function 'f'
	test.lua:6: in function 'g'
	test.lua:9: in main chunk
	[C]: in function 'xpcall'
	init_worker_by_lua:43: in function <init_worker_by_lua:41>
```
