### PR TITLE
tests: added a test case for interrupted file I/O during readall.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
   - git clone https://github.com/openresty/nginx-devel-utils.git
   - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
-  - git clone -b v2.1-agentzh https://github.com/openresty/luajit2.git
+  - git clone -b fix/eintr https://github.com/thibaultcha/luajit2.git
 
 script:
   - cd luajit2/

--- a/t/resty/sanity.t
+++ b/t/resty/sanity.t
@@ -71,3 +71,36 @@ hello
 world
 --- err
 --- ret: 0
+
+
+
+=== TEST 6: catch interrupted fread during file readall (GH issue #35)
+--- src
+local ffi = require "ffi"
+
+ffi.cdef [[
+    int getpid(void);
+]]
+
+local pid = ffi.C.getpid()
+
+local signal = 17
+local platform = assert(io.popen("uname"):read("*l"))
+if platform == "Darwin" then
+    signal = 0
+end
+
+local cmd = string.format("kill -%d %d && sleep 0.1", signal, pid)
+assert(io.popen(cmd):read("*a"))
+--- err
+--- ret: 0
+
+
+
+=== TEST 7: file readall returns syscall errno when not EINTR (GH issue #35)
+--- src
+local f = assert(io.open("/"))
+assert(f:read("*a"))
+--- err_like chomp
+^ERROR:.*?\.lua:2: Is a directory$
+--- ret: 1


### PR DESCRIPTION
Not sure which suite to put the test in for now (signals.t seems to be slightly different). Please provide feedback if it needs to be moved.

It is a bit late right now, so I only tested it on Darwin and Linux, and the test consistently fails when nginx is compiled with openresty/luajit2 -b v2.1-agentzh.

* Failed build (not including the `.travis.yml` change): https://travis-ci.org/thibaultcha/resty-cli/builds/319602486
* Passing build: https://travis-ci.org/thibaultcha/resty-cli/builds/319604486

Let me know how this looks :)