### PR TITLE
tests: added more test cases for interrupted file I/O during read() calls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
   - git clone https://github.com/openresty/nginx-devel-utils.git
   - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
-  - git clone -b v2.1-agentzh https://github.com/openresty/luajit2.git
+  - git clone -b fix/eintr-bis https://github.com/thibaultcha/luajit2.git
 
 script:
   - cd luajit2/

--- a/t/lib/Test/Resty.pm
+++ b/t/lib/Test/Resty.pm
@@ -160,12 +160,18 @@ sub run_test ($) {
         is $err, $block->err, "$name - stderr eq okay";
     }
 
-    $regex = $block->err_like;
-    if (defined $regex) {
+    if (defined $block->err_like) {
+        $regex = $block->err_like;
         if (!ref $regex) {
             $regex = qr/$regex/ms;
         }
         like $err, $regex, "$name - stderr like okay";
+    } elsif (defined $block->err_not_like) {
+        $regex = $block->err_not_like;
+        if (!ref $regex) {
+            $regex = qr/$regex/ms;
+        }
+        unlike $err, $regex, "$name - stderr unlike okay";
     }
 
     my $exp_ret = $block->ret;

--- a/t/resty/sanity.t
+++ b/t/resty/sanity.t
@@ -104,3 +104,105 @@ assert(f:read("*a"))
 --- err_like chomp
 ^ERROR:.*?\.lua:2: Is a directory$
 --- ret: 1
+
+
+
+=== TEST 8: catch interrupted fread during file readbytes
+--- src
+local ffi = require "ffi"
+
+ffi.cdef [[
+    int getpid(void);
+]]
+
+local pid = ffi.C.getpid()
+
+local signal = 17
+local platform = assert(io.popen("uname"):read("*l"))
+if platform == "Darwin" then
+    signal = 0
+end
+
+local cmd = string.format("kill -%d %d && sleep 0.1", signal, pid)
+assert(io.popen(cmd):read(1))
+--- err_not_like chomp
+^ERROR:.*?\.lua:\d+: Interrupted system call$
+--- ret: 1
+
+
+
+=== TEST 9: file readbytes returns syscall errno when not EINTR
+--- src
+local f = assert(io.open("/"))
+assert(f:read(1))
+--- err_like chomp
+^ERROR:.*?\.lua:2: Is a directory$
+--- ret: 1
+
+
+
+=== TEST 10: catch interrupted fscanf during file readnum
+--- src
+local ffi = require "ffi"
+
+ffi.cdef [[
+    int getpid(void);
+]]
+
+local pid = ffi.C.getpid()
+
+local signal = 17
+local platform = assert(io.popen("uname"):read("*l"))
+if platform == "Darwin" then
+    signal = 0
+end
+
+local cmd = string.format("kill -%d %d && sleep 0.1", signal, pid)
+assert(io.popen(cmd):read("*n"))
+--- err_not_like chomp
+^ERROR:.*?\.lua:\d+: Interrupted system call$
+--- ret: 1
+
+
+
+=== TEST 11: file readnum returns syscall errno when not EINTR
+--- src
+local f = assert(io.open("/"))
+assert(f:read("*n"))
+--- err_like chomp
+^ERROR:.*?\.lua:2: Is a directory$
+--- ret: 1
+
+
+
+=== TEST 12: catch interrupted fgets during file readline
+--- src
+local ffi = require "ffi"
+
+ffi.cdef [[
+    int getpid(void);
+]]
+
+local pid = ffi.C.getpid()
+
+local signal = 17
+local platform = assert(io.popen("uname"):read("*l"))
+if platform == "Darwin" then
+    signal = 0
+end
+
+local cmd = string.format("kill -%d %d && sleep 0.1 && echo '\n'", signal, pid)
+assert(io.popen(cmd):read("*l"))
+--- err_not_like chomp
+^ERROR:.*?\.lua:\d+: Interrupted system call$
+--- ret: 0
+
+
+
+=== TEST 13: file readline returns syscall errno when not EINTR
+--- src
+local f = assert(io.open("/"))
+assert(f:read("*l"))
+--- err_like chomp
+^ERROR:.*?\.lua:2: Is a directory$
+--- ret: 1


### PR DESCRIPTION
Cover other modes for `io.read()`:
- `"*n"`
- `"*l"`
- `n`