### PR TITLE
bugfix: fixed bug that when signal is received and children is already

### DIFF
--- a/bin/resty
+++ b/bin/resty
@@ -17,7 +17,7 @@ use List::Util qw( max );
 use Getopt::Long qw( GetOptions :config no_ignore_case require_order);
 use File::Temp qw( tempdir );
 use POSIX qw( WNOHANG );
-use Errno qw(ESRCH ECHILD :POSIX);
+use Errno qw(ESRCH ECHILD EINTR :POSIX);
 use Time::HiRes qw( sleep );
 
 sub resolve_includes {
@@ -482,7 +482,7 @@ sub forward_signal {
         #warn "killing $child_pid with $signame ...\n";
 
         if ($signame eq 'INT' || $signame eq 'PIPE') {
-            if (kill QUIT => $child_pid != 0) {
+            if ((kill QUIT => $child_pid) == 0) {
                 if (not $!{ESRCH}) {
                     die "failed to send QUIT signal to process $child_pid: $!";
                 }
@@ -494,7 +494,7 @@ sub forward_signal {
             exit($signame eq 'INT' ? 130 : 141);
 
         } else {
-            if (kill $signame => $child_pid != 0) {
+            if ((kill $signame => $child_pid) == 0) {
                 if (not $!{ESRCH}) {
                     die "failed to send $signame signal to process ",
                         "$child_pid: $!";

--- a/bin/resty
+++ b/bin/resty
@@ -17,6 +17,7 @@ use List::Util qw( max );
 use Getopt::Long qw( GetOptions :config no_ignore_case require_order);
 use File::Temp qw( tempdir );
 use POSIX qw( WNOHANG );
+use Errno qw(ESRCH ECHILD :POSIX);
 use Time::HiRes qw( sleep );
 
 sub resolve_includes {
@@ -482,7 +483,8 @@ sub forward_signal {
 
         if ($signame eq 'INT' || $signame eq 'PIPE') {
             kill QUIT => $child_pid
-                or die "failed to send QUIT signal to process $child_pid: $!";
+                or not $!{ESRCH}
+                and die "failed to send QUIT signal to process $child_pid: $!";
 
             sleep 0.1;
 
@@ -491,8 +493,9 @@ sub forward_signal {
 
         } else {
             kill $signame => $child_pid
-                or die "failed to send $signame signal to process ",
-                       "$child_pid: $!";
+                or not $!{ESRCH}
+                and die "failed to send $signame signal to process ",
+                        "$child_pid: $!";
         }
 
         my $nap = 0.001;
@@ -505,7 +508,8 @@ sub forward_signal {
 
             my $ret = waitpid $child_pid, WNOHANG;
             next if $ret == 0;
-            last if $ret < 0;
+            exit 0 if $!{ECHILD};
+            die $! if $ret < 0;
 
             my $rc = 0;
             if ($signame eq 'INT') {
@@ -521,6 +525,7 @@ sub forward_signal {
                     $rc = $?;
                 }
             }
+
             exit $rc;
         }
     }
@@ -544,6 +549,7 @@ if ($pid == 0) {  # child process
 } else {
     $child_pid = $pid;
     waitpid($child_pid, 0);
+
     my $rc = 0;
     if ($?) {
         $rc = ($? >> 8);

--- a/bin/resty
+++ b/bin/resty
@@ -482,9 +482,11 @@ sub forward_signal {
         #warn "killing $child_pid with $signame ...\n";
 
         if ($signame eq 'INT' || $signame eq 'PIPE') {
-            kill QUIT => $child_pid
-                or not $!{ESRCH}
-                and die "failed to send QUIT signal to process $child_pid: $!";
+            if (kill QUIT => $child_pid != 0) {
+                if (not $!{ESRCH}) {
+                    die "failed to send QUIT signal to process $child_pid: $!";
+                }
+            }
 
             sleep 0.1;
 
@@ -492,10 +494,12 @@ sub forward_signal {
             exit($signame eq 'INT' ? 130 : 141);
 
         } else {
-            kill $signame => $child_pid
-                or not $!{ESRCH}
-                and die "failed to send $signame signal to process ",
+            if (kill $signame => $child_pid != 0) {
+                if (not $!{ESRCH}) {
+                    die "failed to send $signame signal to process ",
                         "$child_pid: $!";
+                }
+            }
         }
 
         my $nap = 0.001;
@@ -509,7 +513,7 @@ sub forward_signal {
             my $ret = waitpid $child_pid, WNOHANG;
             next if $ret == 0;
             exit 0 if $!{ECHILD};
-            die $! if $ret < 0;
+            die "failed to wait on child process $child_pid: $!" if $ret < 0;
 
             my $rc = 0;
             if ($signame eq 'INT') {
@@ -525,7 +529,6 @@ sub forward_signal {
                     $rc = $?;
                 }
             }
-
             exit $rc;
         }
     }
@@ -549,7 +552,6 @@ if ($pid == 0) {  # child process
 } else {
     $child_pid = $pid;
     waitpid($child_pid, 0);
-
     my $rc = 0;
     if ($?) {
         $rc = ($? >> 8);

--- a/t/resty/signals.t
+++ b/t/resty/signals.t
@@ -210,3 +210,36 @@ for (1..3) {
 GOT SIGQUIT
 --- ret: 141
 --- err
+
+
+
+=== TEST 9: Rapidly send SIGWINCH while child is exiting
+--- opts: -e 'print(1)'
+--- mock_nginx
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+my $resty_pid = getppid();
+my $pid = fork();
+
+if ($pid == 0) {
+    for (1..10) {
+        kill WINCH => $resty_pid or die "failed to send SIGWINCH";
+        sleep(0.001);
+    }
+
+    exit(0);
+}
+
+for (1..5) {
+    sleep(0.001);
+}
+
+print("done");
+exit(0);
+
+--- out chop
+done
+--- ret: 0
+--- err


### PR DESCRIPTION
gone, resty incorrectly returns non-zero return code and outputs "No
such process" error.

Here is a method to reproduce this bug easily using Mac Terminal SSHed to a remote Linux box:
1. Resize the Terminal window to make it small
2. Run `make clean && make` under [meta-lua-nginx-module](https://github.com/openresty/meta-lua-nginx-module)
3. Double click the Terminal title to make it fill the screen while `make` is running, this will results in large amount of `SIGWINCH` being sent to `resty`

Additionally, the included test should be able to reproduce this easily as well.

Here is what the error looks like:

```shell
[datong@localhost meta-lua-nginx-module]$ make
mkdir build
mkdir build/src
mkdir build/src/api
lemplate --compile src/subsystem/ngx_subsystem_lua_ssl.h.tt2 src/subsystem/ngx_subsystem_lua_time.c.tt2 src/subsystem/ngx_subsystem_lua_coroutine.h.tt2 src/subsystem/ngx_subsystem_lua_util.h.tt2 src/subsystem/ngx_subsystem_lua_lex.h.tt2 src/subsystem/ngx_subsystem_lua_util.c.tt2 src/subsystem/ngx_subsystem_lua_string.h.tt2 src/subsystem/ngx_subsystem_lua_regex.h.tt2 src/subsystem/ngx_subsystem_lua_probe.h.tt2 src/subsystem/ngx_subsystem_lua_ctx.c.tt2 src/subsystem/ngx_subsystem_lua_phase.h.tt2 src/subsystem/ngx_subsystem_lua_timer.c.tt2 src/subsystem/ngx_subsystem_lua_socket_tcp.h.tt2 src/subsystem/ngx_subsystem_lua_timer.h.tt2 src/subsystem/ngx_subsystem_lua_string.c.tt2 src/subsystem/ngx_subsystem_lua_time.h.tt2 src/subsystem/ngx_subsystem_lua_api.c.tt2 src/subsystem/ngx_subsystem_lua_module.c.tt2 src/subsystem/ngx_subsystem_lua_logby.c.tt2 src/subsystem/ngx_subsystem_lua_initworkerby.h.tt2 src/subsystem/ngx_subsystem_lua_phase.c.tt2 src/subsystem/ngx_subsystem_lua_variable.h.tt2 src/subsystem/ngx_subsystem_lua_script.h.tt2 src/subsystem/ngx_subsystem_lua_common.h.tt2 src/subsystem/ngx_subsystem_lua_socket_tcp.c.tt2 src/subsystem/ngx_subsystem_lua_clfactory.c.tt2 src/subsystem/ngx_subsystem_lua_ssl.c.tt2 src/subsystem/ngx_subsystem_lua_initworkerby.c.tt2 src/subsystem/ngx_subsystem_lua_sleep.h.tt2 src/subsystem/ngx_subsystem_lua_balancer.h.tt2 src/subsystem/ngx_subsystem_lua_log.h.tt2 src/subsystem/ngx_subsystem_lua_args.h.tt2 src/subsystem/ngx_subsystem_lua_config.h.tt2 src/subsystem/ngx_subsystem_lua_misc.c.tt2 src/subsystem/ddebug.h.tt2 src/subsystem/ngx_subsystem_lua_script.c.tt2 src/subsystem/ngx_subsystem_lua_output.h.tt2 src/subsystem/ngx_subsystem_lua_args.c.tt2 src/subsystem/ngx_subsystem_lua_lex.c.tt2 src/subsystem/ngx_subsystem_lua_coroutine.c.tt2 src/subsystem/ngx_subsystem_lua_balancer.c.tt2 src/subsystem/ngx_subsystem_lua_pcrefix.h.tt2 src/subsystem/ngx_subsystem_lua_uthread.h.tt2 src/subsystem/ngx_subsystem_lua_config.c.tt2 src/subsystem/ngx_subsystem_lua_shdict.h.tt2 src/subsystem/ngx_subsystem_lua_clfactory.h.tt2 src/subsystem/ngx_subsystem_lua_exception.h.tt2 src/subsystem/ngx_subsystem_lua_output.c.tt2 src/subsystem/ngx_subsystem_lua_sleep.c.tt2 src/subsystem/ngx_subsystem_lua_log.c.tt2 src/subsystem/ngx_subsystem_lua_initby.h.tt2 src/subsystem/ngx_subsystem_lua_contentby.h.tt2 src/subsystem/ngx_subsystem_lua_regex.c.tt2 src/subsystem/ngx_subsystem_lua_uthread.c.tt2 src/subsystem/ngx_subsystem_lua_shdict.c.tt2 src/subsystem/ngx_subsystem_lua_directive.c.tt2 src/subsystem/ngx_subsystem_lua_socket_udp.c.tt2 src/subsystem/ngx_subsystem_lua_exception.c.tt2 src/subsystem/ngx_subsystem_lua_logby.h.tt2 src/subsystem/ngx_subsystem_lua_contentby.c.tt2 src/subsystem/ngx_subsystem_lua_initby.c.tt2 src/subsystem/ngx_subsystem_lua_control.h.tt2 src/subsystem/ngx_subsystem_lua_pcrefix.c.tt2 src/subsystem/ngx_subsystem_lua_cache.h.tt2 src/subsystem/ngx_subsystem_lua_control.c.tt2 src/subsystem/ngx_subsystem_lua_variable.c.tt2 src/subsystem/ngx_subsystem_lua_worker.c.tt2 src/subsystem/ngx_subsystem_lua_consts.h.tt2 src/subsystem/ngx_subsystem_lua_cache.c.tt2 src/subsystem/ngx_subsystem_lua_socket_udp.h.tt2 src/subsystem/ngx_subsystem_lua_worker.h.tt2 src/subsystem/ngx_subsystem_lua_consts.c.tt2 src/subsystem/ngx_subsystem_lua_directive.h.tt2 src/subsystem/ngx_subsystem_lua_misc.h.tt2 src/subsystem/ngx_subsystem_lua_ctx.h.tt2 src/subsystem/api/ngx_subsystem_lua_api.h.tt2 build > build/templates.lua
Name "Text::Glob::seperator" used only once: possible typo at Text/Glob.pm line 24.
resty utils/run_template.lua http ngx_http_lua_ssl.h
resty utils/run_template.lua http ngx_http_lua_time.c
resty utils/run_template.lua http ngx_http_lua_coroutine.h
resty utils/run_template.lua http ngx_http_lua_util.h
resty utils/run_template.lua http ngx_http_lua_lex.h
resty utils/run_template.lua http ngx_http_lua_util.c
resty utils/run_template.lua http ngx_http_lua_string.h
resty utils/run_template.lua http ngx_http_lua_regex.h
resty utils/run_template.lua http ngx_http_lua_probe.h
resty utils/run_template.lua http ngx_http_lua_ctx.c
resty utils/run_template.lua http ngx_http_lua_phase.h
failed to send WINCH to process 90079: No such process at /home/datong/openresty-build/bin/resty line 398.
END failed--call queue aborted.
make: *** [Makefile:15: build/src/ngx_http_lua_phase.h] Error 3
```

To fix it, we fall through when `kill()`'s `errno = ESRCH`. Later on if `waitpid()` returns `errno = ECHILD`, we simply quit normally as that means the children is gone already.