### PR TITLE
tests: added more test cases for retries on interrupted file I/O.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
   - git clone https://github.com/openresty/openresty.git ../openresty
   - git clone https://github.com/openresty/lua-resty-core.git ../lua-resty-core
   - git clone https://github.com/openresty/nginx-devel-utils.git
-  - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
+  - git clone -b feat/sa-restart https://github.com/thibaultcha/lua-nginx-module.git ../lua-nginx-module
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone -b v2.1-agentzh https://github.com/openresty/luajit2.git
 

--- a/t/lib/Test/Resty.pm
+++ b/t/lib/Test/Resty.pm
@@ -207,6 +207,21 @@ sub run_test ($) {
         warn "STDERR:\n$err\n";
     }
 
+    if (defined $block->err_like) {
+        $regex = $block->err_like;
+        if (!ref $regex) {
+            $regex = qr/$regex/ms;
+        }
+        like $err, $regex, "$name - stderr like okay";
+
+    } elsif (defined $block->err_not_like) {
+        $regex = $block->err_not_like;
+        if (!ref $regex) {
+            $regex = qr/$regex/ms;
+        }
+        unlike $err, $regex, "$name - stderr unlike okay";
+    }
+
     my $exp_ret = $block->ret;
     if (!defined $exp_ret) {
         $exp_ret = 0;


### PR DESCRIPTION
This is one of 4 PRs to properly handle `EINTR` errors in resty-cli (and/or OpenResty if desired by the user).

- https://github.com/openresty/luajit2/pull/18 Revert the "retry on EINTR" patch
- https://github.com/openresty/lua-nginx-module/pull/1296 Implement an FFI API to enable `SA_RESTART` on signal handlers
- https://github.com/openresty/lua-resty-core/pull/183 Implement the Lua `sig_restart()` API
- (this PR) Enable the `SA_RESTART` flag on interrupting signals

If all PRs are merged:
- we get rid of the "retry on EINTR" LuaJIT patch which was refused upstream
- resty-cli users can safely use APIs like `io.popen()` https://github.com/openresty/resty-cli/issues/35
- OpenResty users can toggle this behaviour on/off as desired (off by default)