### PR TITLE
move main_include and main_conf section ahead

### DIFF
--- a/bin/resty
+++ b/bin/resty
@@ -715,6 +715,8 @@ master_process off;
 worker_processes 1;
 pid logs/nginx.pid;
 
+$main_conf_lines
+$main_include_directives
 $env_list
 
 error_log stderr $errlog_level;
@@ -723,9 +725,6 @@ error_log stderr $errlog_level;
 events {
     worker_connections $conns;
 }
-
-$main_conf_lines
-$main_include_directives
 
 http {
     access_log off;


### PR DESCRIPTION
make **load_module**  directive work in $main_include_directives and $main_conf_lines. 
Which in `resty --main-include ./main.conf --http-include ./http.conf `

`load_module /usr/local/openresty/modules/ngx_lua_ipc_module.so;`
`load_module ../modules/ngx_http_vhost_traffic_status_module.so;`