### PR TITLE
restydoc-index: shell quote the markdown file path.

### DIFF
--- a/bin/restydoc-index
+++ b/bin/restydoc-index
@@ -139,13 +139,14 @@ sub wanted {
             or die "cannot copy $docfile to $podfile: $!\n";
 
     } else {
-        my $mdfile = $docfile;
+        my $quoted_mdfile = shell_quote($docfile);
 
         #warn $name;
         #warn "wanted: $File::Find::dir $File::Find::name $_\n";
         $podfile = "$poddir/$name.pod";
+        my $quoted_podfile = shell_quote($podfile);
         #warn "$name => $podfile";
-        shell("$FindBin::RealBin/md2pod.pl -o $podfile $mdfile");
+        shell("$FindBin::RealBin/md2pod.pl -o $quoted_podfile $quoted_mdfile");
     }
 
     my $dist_module = process_pod($podfile, $name);
@@ -356,4 +357,25 @@ sub gen_aliases {
     }
 
     return @aliases;
+}
+
+sub shell_quote() {
+    my $ret = shift;
+
+    if (!defined $ret or $ret eq '') {
+        return "''";
+    }
+
+    if (m|[^\w!%+,\-./:=@^]|) {
+        $ret =~ s/'/'\\''/g;
+
+        # make multiple ' in a row look simpler
+        # '\'''\'''\'' -> '"'''"'
+        $ret =~ s|((?:'\\''){2,})|q{'"} . (q{'} x (length($1) / 4)) . q{"'}|ge;
+        $ret = "'$ret'";
+        $ret =~ s/^''//;
+        $ret =~ s/''$//;
+    }
+
+    return $ret;
 }

--- a/bin/restydoc-index
+++ b/bin/restydoc-index
@@ -368,7 +368,7 @@ sub shell_quote ($) {
         return "''";
     }
 
-    if ($ret =~ s/[[:cntrl:]\t\r\n]//g) {
+    if ($ret =~ s/[[:cntrl:]]//g) {
         die "shell_quote(): No way to quote string containing control characters\n";
     }
 

--- a/bin/restydoc-index
+++ b/bin/restydoc-index
@@ -366,6 +366,10 @@ sub shell_quote() {
         return "''";
     }
 
+    if ($ret =~ s/\x00//g) {
+        die "shell_quote(): No way to quote string containing null (\\000) bytes\n";
+    }
+
     if (m|[^\w!%+,\-./:=@^]|) {
         $ret =~ s/'/'\\''/g;
 

--- a/bin/restydoc-index
+++ b/bin/restydoc-index
@@ -370,7 +370,7 @@ sub shell_quote() {
         die "shell_quote(): No way to quote string containing null (\\000) bytes\n";
     }
 
-    if (m|[^\w!%+,\-./:=@^]|) {
+    if ($ret =~ m|[^\w!%+,\-./:=@^]|) {
         $ret =~ s/'/'\\''/g;
 
         # make multiple ' in a row look simpler

--- a/bin/restydoc-index
+++ b/bin/restydoc-index
@@ -372,7 +372,7 @@ sub shell_quote ($) {
         die "shell_quote(): No way to quote string containing control characters\n";
     }
 
-    $ret =~ s/([#&;`'"|*?~!<>^\(\)\[\]\{\}\$\\, ])/\\$1/g;
+    $ret =~ s/([#&;`'"|*?~!<>^()\[\]{}\$\\, ])/\\$1/g;
 
     return $ret;
 }

--- a/bin/restydoc-index
+++ b/bin/restydoc-index
@@ -368,6 +368,10 @@ sub shell_quote ($) {
         return "''";
     }
 
+    if ($ret =~ s/[\x00-\x1F\t\r\n]//g) {
+        die "shell_quote(): No way to quote string containing control characters\n";
+    }
+
     $ret =~ s/([#&;`'"|*?~!<>^\(\)\[\]\{\}\$\\, ])/\\$1/g;
 
     return $ret;

--- a/bin/restydoc-index
+++ b/bin/restydoc-index
@@ -368,7 +368,7 @@ sub shell_quote ($) {
         return "''";
     }
 
-    if ($ret =~ s/[\x00-\x1F\t\r\n]//g) {
+    if ($ret =~ s/[[:cntrl:]\t\r\n]//g) {
         die "shell_quote(): No way to quote string containing control characters\n";
     }
 

--- a/bin/restydoc-index
+++ b/bin/restydoc-index
@@ -368,20 +368,7 @@ sub shell_quote ($) {
         return "''";
     }
 
-    if ($ret =~ s/\x00//g) {
-        die "shell_quote(): No way to quote string containing null (\\000) bytes\n";
-    }
-
-    if ($ret =~ m|[^\w!%+,\-./:=@^]|) {
-        $ret =~ s/'/'\\''/g;
-
-        # make multiple ' in a row look simpler
-        # '\'''\'''\'' -> '"'''"'
-        $ret =~ s|((?:'\\''){2,})|q{'"} . (q{'} x (length($1) / 4)) . q{"'}|ge;
-        $ret = "'$ret'";
-        $ret =~ s/^''//;
-        $ret =~ s/''$//;
-    }
+    $ret =~ s/([#&;`'"|*?~!<>^\(\)\[\]\{\}\$\\, ])/\\$1/g;
 
     return $ret;
 }

--- a/bin/restydoc-index
+++ b/bin/restydoc-index
@@ -368,7 +368,7 @@ sub shell_quote ($) {
         return "''";
     }
 
-    if ($ret =~ s/[[:cntrl:]]//g) {
+    if ($ret =~ /[[:cntrl:]]/) {
         die "shell_quote(): No way to quote string containing control characters\n";
     }
 

--- a/bin/restydoc-index
+++ b/bin/restydoc-index
@@ -12,6 +12,8 @@ use File::Path qw( make_path );
 use Getopt::Long qw( GetOptions );
 use bytes ();
 
+sub shell_quote ($);
+
 GetOptions(
     "outdir=s" => \(my $outdir),
 ) or die "Usage: $0 [--outdir DIR] DIR\n";
@@ -139,12 +141,12 @@ sub wanted {
             or die "cannot copy $docfile to $podfile: $!\n";
 
     } else {
-        my $quoted_mdfile = shell_quote($docfile);
+        my $quoted_mdfile = shell_quote $docfile;
 
         #warn $name;
         #warn "wanted: $File::Find::dir $File::Find::name $_\n";
         $podfile = "$poddir/$name.pod";
-        my $quoted_podfile = shell_quote($podfile);
+        my $quoted_podfile = shell_quote $podfile;
         #warn "$name => $podfile";
         shell("$FindBin::RealBin/md2pod.pl -o $quoted_podfile $quoted_mdfile");
     }
@@ -359,7 +361,7 @@ sub gen_aliases {
     return @aliases;
 }
 
-sub shell_quote() {
+sub shell_quote ($) {
     my $ret = shift;
 
     if (!defined $ret or $ret eq '') {


### PR DESCRIPTION
for avoiding shell injection attacks.